### PR TITLE
add credential status for issuer data

### DIFF
--- a/verifiable/credential.go
+++ b/verifiable/credential.go
@@ -33,10 +33,11 @@ type StatusIssuer struct {
 
 // CredentialStatus contains type and revocation Url
 type CredentialStatus struct {
-	ID           string               `json:"id"`
-	Type         CredentialStatusType `json:"type"`
-	Issuer       string               `json:"issuer,omitempty"`
-	StatusIssuer *StatusIssuer        `json:"statusIssuer,omitempty"`
+	ID              string               `json:"id"`
+	Type            CredentialStatusType `json:"type"`
+	Issuer          string               `json:"issuer,omitempty"`
+	RevocationNonce *uint64              `json:"revocationNonce,omitempty"`
+	StatusIssuer    *StatusIssuer        `json:"statusIssuer,omitempty"`
 }
 
 //nolint:gosec //reason: no need for security

--- a/verifiable/proof.go
+++ b/verifiable/proof.go
@@ -7,11 +7,11 @@ import (
 
 // IssuerData is the data that is used to create a proof
 type IssuerData struct {
-	ID               *core.ID    `json:"id,omitempty"`
-	State            State       `json:"state,omitempty"`
-	AuthClaim        *core.Claim `json:"auth_claim,omitempty"`
-	MTP              *mt.Proof   `json:"mtp,omitempty"`
-	RevocationStatus string      `json:"revocation_status,omitempty"`
+	ID               *core.ID          `json:"id,omitempty"`
+	State            State             `json:"state,omitempty"`
+	AuthClaim        *core.Claim       `json:"auth_claim,omitempty"`
+	MTP              *mt.Proof         `json:"mtp,omitempty"`
+	RevocationStatus *CredentialStatus `json:"revocation_status,omitempty"`
 }
 
 // State represents the state of the issuer


### PR DESCRIPTION
:warning: update https://github.com/iden3/claim-schema-vocab before marge.
Need to refactor `proof.BJJSignature2021.issuer_data.revocation_status` vocab. And add `RevocationNonce` to `CredentialStatus`