### PR TITLE
Normalize json-ld in safe mode

### DIFF
--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.20.1
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.1

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         containers:
         - 1.18.10-bullseye
-        - 1.19.5-bullseye
-        - 1.20rc3-bullseye
+        - 1.19.6-bullseye
+        - 1.20.1-bullseye
     runs-on: ubuntu-latest
     container: golang:${{ matrix.containers }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,17 +39,13 @@ linters:
     - govet
     - unconvert
     - megacheck
-    - structcheck
     - gas
     - gocyclo
     - dupl
     - misspell
     - unparam
-    - varcheck
-    - deadcode
     - typecheck
     - ineffassign
-    - varcheck
     - stylecheck
     - gochecknoinits
     - exportloopref
@@ -57,6 +53,7 @@ linters:
     - nakedret
     - gosimple
     - prealloc
+    - unused
 
     ## format - fill free to fix
 #    - errcheck

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,11 @@ require (
 	github.com/iden3/go-iden3-crypto v0.0.13
 	github.com/iden3/go-merkletree-sql/v2 v2.0.0
 	github.com/ipfs/go-ipfs-api v0.3.0
-	github.com/piprate/json-gold v0.5.0
+	// We require the `json-gold` bugfix which has not yet been included in the
+	// stable version. After the release of version 0.5.1 or later, it will be
+	// necessary to update to the stable version.
+	// https://github.com/piprate/json-gold/commit/36fcca9d7e487684a764e552e7d837a14546a157
+	github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f
 	github.com/pkg/errors v0.9.1
 	github.com/qri-io/jsonschema v0.2.1
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/piprate/json-gold v0.5.0 h1:RmGh1PYboCFcchVFuh2pbSWAZy4XJaqTMU4KQYsApbM=
-github.com/piprate/json-gold v0.5.0/go.mod h1:WZ501QQMbZZ+3pXFPhQKzNwS1+jls0oqov3uQ2WasLs=
+github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f h1:HlPa7RcxTCrva5izPfTEfvYecO7LTahgmMRD1Qp13xg=
+github.com/piprate/json-gold v0.5.1-0.20230111113000-6ddbe6e6f19f/go.mod h1:WZ501QQMbZZ+3pXFPhQKzNwS1+jls0oqov3uQ2WasLs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/merklize/merklize.go
+++ b/merklize/merklize.go
@@ -1166,6 +1166,7 @@ type Merklizer struct {
 	mt        MerkleTree
 	entries   map[string]RDFEntry
 	hasher    Hasher
+	safeMode  bool
 }
 
 // MerklizeOption is options for merklizer
@@ -1185,12 +1186,23 @@ func WithMerkleTree(mt MerkleTree) MerklizeOption {
 	}
 }
 
+// WithSafeMode enables the Safe mode when extending a JSON-LD document.
+// The default setting for this mode is "true". If the function encounters
+// an unknown field with an incorrect IRI predicate, it will return an error.
+// However, if the Safe mode is set to "false", the function will simply skip
+// the incorrect field and continue the merklization process without it.
+func WithSafeMode(safeMode bool) MerklizeOption {
+	return func(m *Merklizer) {
+		m.safeMode = safeMode
+	}
+}
+
 // MerklizeJSONLD takes a JSON-LD document, parses it and returns a
 // Merklizer
 func MerklizeJSONLD(ctx context.Context, in io.Reader,
 	opts ...MerklizeOption) (*Merklizer, error) {
 
-	mz := &Merklizer{}
+	mz := &Merklizer{safeMode: true}
 	for _, o := range opts {
 		o(mz)
 	}
@@ -1223,7 +1235,8 @@ func MerklizeJSONLD(ctx context.Context, in io.Reader,
 
 	proc := ld.NewJsonLdProcessor()
 	options := ld.NewJsonLdOptions("")
-	options.Algorithm = "URDNA2015"
+	options.Algorithm = ld.AlgorithmURDNA2015
+	options.SafeMode = mz.safeMode
 
 	normDoc, err := proc.Normalize(obj, options)
 	if err != nil {

--- a/merklize/merklize.go
+++ b/merklize/merklize.go
@@ -1396,11 +1396,11 @@ func mkValueMtEntry(h Hasher, v interface{}) (*big.Int, error) {
 	case int:
 		return mkValueInt(h, et)
 	case uint64:
-		return mkValueUInt(h, et)
+		return mkValueUInt(et)
 	case uint32:
-		return mkValueUInt(h, et)
+		return mkValueUInt(et)
 	case uint:
-		return mkValueUInt(h, et)
+		return mkValueUInt(et)
 	case bool:
 		return mkValueBool(h, et)
 	case string:
@@ -1420,7 +1420,7 @@ func mkValueInt[I int64 | int32 | int](h Hasher, val I) (*big.Int, error) {
 	}
 }
 
-func mkValueUInt[I uint64 | uint32 | uint](h Hasher, val I) (*big.Int, error) {
+func mkValueUInt[I uint64 | uint32 | uint](val I) (*big.Int, error) {
 	return new(big.Int).SetUint64(uint64(val)), nil
 }
 

--- a/merklize/merklize_test.go
+++ b/merklize/merklize_test.go
@@ -957,3 +957,32 @@ func TestMerklizer_RawValue(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, float64(19960425), val)
 }
+
+func TestIncorrectDocument_UnsafeMode(t *testing.T) {
+	const docUnknownFields = `{
+    "id": "http://127.0.0.1/id",
+    "expirationDate": "2030-01-01T00:00:00Z"
+}`
+
+	ctx := context.Background()
+
+	t.Run("default safe mode", func(t *testing.T) {
+		_, err := MerklizeJSONLD(ctx, strings.NewReader(docUnknownFields))
+		require.EqualError(t, err,
+			"invalid property: Dropping property that did not expand into an absolute IRI or keyword.")
+
+	})
+
+	t.Run("explicitly set safe mode", func(t *testing.T) {
+		_, err := MerklizeJSONLD(ctx, strings.NewReader(docUnknownFields),
+			WithSafeMode(true))
+		require.EqualError(t, err,
+			"invalid property: Dropping property that did not expand into an absolute IRI or keyword.")
+	})
+
+	t.Run("explicitly set unsafe mode", func(t *testing.T) {
+		_, err := MerklizeJSONLD(ctx, strings.NewReader(docUnknownFields),
+			WithSafeMode(false))
+		require.NoError(t, err)
+	})
+}

--- a/merklize/merklize_test.go
+++ b/merklize/merklize_test.go
@@ -760,11 +760,6 @@ var doc1 = `
         "VerifiableCredential",
         "KYCAgeCredential"
     ],
-    "version": 0,
-    "updatable": false,
-    "subjectPosition": "index",
-    "revNonce": 127366661,
-    "merklizedRootPosition": "index",
     "id": "http://myid.com",
     "expirationDate": "2361-03-21T21:14:48+02:00",
     "credentialSubject": {

--- a/merklize/merklize_test.go
+++ b/merklize/merklize_test.go
@@ -461,7 +461,7 @@ func TestMerklizer_Proof(t *testing.T) {
 		require.NoError(t, err)
 
 		birthDate := time.Date(1958, 7, 18, 0, 0, 0, 0, time.UTC)
-		birthDate.Equal(valueDateType)
+		require.True(t, birthDate.Equal(valueDateType))
 
 		valueMtEntry, err := value.MtEntry()
 		require.NoError(t, err)

--- a/verifiable/credential.go
+++ b/verifiable/credential.go
@@ -84,7 +84,7 @@ type CredentialStatus struct {
 type RHSCredentialStatus struct {
 	ID              string               `json:"id"`
 	Type            CredentialStatusType `json:"type"`
-	RevocationNonce uint64               `json:"revocationNonce,omitempty"`
+	RevocationNonce uint64               `json:"revocationNonce"`
 	StatusIssuer    *CredentialStatus    `json:"statusIssuer,omitempty"`
 }
 


### PR DESCRIPTION
The default behavior has been modified. We now normalize JSON-LD documents in safe mode, which means that if we encounter an unknown field, we will return an error. It is possible to change this mode by using the WithSafeMode option. In unsafe mode, unknown fields will be skipped, and the document will be normalized without them.

Additionally, RHSCredentialStatus will always be marshaled with revocationNonce, even if its value is zero.