### PR TITLE
PID-455 canonize string represented double values

### DIFF
--- a/merklize/merklize.go
+++ b/merklize/merklize.go
@@ -1675,7 +1675,12 @@ func mkValueString(h Hasher, val string) (*big.Int, error) {
 }
 
 func mkValueTime(h Hasher, val time.Time) (*big.Int, error) {
-	return mkValueInt(h, val.UnixNano())
+	var x = new(big.Int).Mul(
+		big.NewInt(val.Unix()),
+		big.NewInt(1_000_000_000))
+	x.Add(x, big.NewInt(int64(val.Nanosecond())))
+	x.Mod(x, h.Prime())
+	return x, nil
 }
 
 // assert consistency of dataset and validate that only

--- a/merklize/merklize_test.go
+++ b/merklize/merklize_test.go
@@ -1236,6 +1236,12 @@ func TestHashValue(t *testing.T) {
 			wantHash: "1546300800000000000",
 		},
 		{
+			name:     "xsd:dateTime in the distant future",
+			datatype: "http://www.w3.org/2001/XMLSchema#dateTime",
+			value:    "4000-01-01T00:00:00Z",
+			wantHash: "64060588800000000000",
+		},
+		{
 			name:     "xsd:dateTime < January 1st, 1970 RFC3339Nano",
 			datatype: "http://www.w3.org/2001/XMLSchema#dateTime",
 			value:    "1960-02-20T11:20:33Z",


### PR DESCRIPTION
* Canonize string represented double values
* Fix time representation for dates beyond 2300 year.